### PR TITLE
Swamy/02may work

### DIFF
--- a/.cursor/rules/02_repository-structure.mdc
+++ b/.cursor/rules/02_repository-structure.mdc
@@ -103,20 +103,20 @@ python-fundamentals/
 │       │   ├── 01_conditionals.py
 │       │   ├── 02_boolean_logic.py
 │       │   └── 03_number_guessing_game.py
-│       ├── S6/                 # Session 6 practice files
+│       ├── S6/                 # Session 5 practice files
 │       │   ├── 01_for_loops.py
 │       │   ├── 02_while_loops.py
 │       │   ├── 03_loop_controls_fizzbuzz.py
 │       │   └── 04_calculator_loop.py
-│       ├── S7/                 # Session 7 practice files
+│       ├── S7/                 # Session 6 practice files
 │       │   ├── 01_error_examples.py
 │       │   ├── 02_debug_practice.py
 │       │   └── 03_builtin_functions.py
-│       ├── S8/                 # Session 8 practice files
+│       ├── S8/                 # Session 7 practice files
 │       │   ├── 01_list_basics.py
 │       │   ├── 02_list_methods.py
 │       │   └── 03_task_manager.py
-│       ├── S9/                 # Session 9 practice files
+│       ├── S9/                 # Session 8 practice files
 │       │   ├── 01_dict_basics.py
 │       │   ├── 02_dict_iteration.py
 │       │   └── 03_gradebook.py
@@ -142,19 +142,19 @@ python-fundamentals/
 │       │   ├── 01_basic_error_handling.py
 │       │   ├── 02_multiple_exceptions.py
 │       │   └── 03_else_finally.py
-│       ├── S6/                 # Session 6 practice files
+│       ├── S6/                 # Session 5 practice files
 │       │   ├── 01_basic_parameters.py
 │       │   ├── 02_parameter_types.py
 │       │   └── 03_return_values.py
-│       ├── S7/                 # Session 7 practice files
+│       ├── S7/                 # Session 6 practice files
 │       │   ├── 01_local_scope.py
 │       │   ├── 02_global_scope.py
 │       │   └── 03_code_organization.py
-│       ├── S8/                 # Session 8 practice files
+│       ├── S8/                 # Session 7 practice files
 │       │   ├── 01_reading_files.py
 │       │   ├── 02_writing_files.py
 │       │   └── 03_file_operations.py
-│       ├── S9/                 # Session 9 practice files
+│       ├── S9/                 # Session 8 practice files
 │       │   ├── 01_creating_modules.py
 │       │   ├── 02_name_main.py
 │       │   └── 03_multi_file_project.py

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,14 +81,14 @@ python-fundamentals/
 │   │   │   ├── 01_hello.py
 │   │   │   ├── 02_interactive_hello.py
 │   │   │   └── bytecode_demo.py
-│   │   ├── S2/ ... S9/      # Session 2-9 practice files
+│   │   ├── S2/ ... S9/      # Numbered session folders for regular sessions (mini projects are separate)
 │   │   ├── S5_MP1/          # Session 5 Mini Project 1 files
 │   │   │   ├── 01_simple_calculator.py
 │   │   │   └── calculator_utils.py
 │   │   └── S10_MP2/         # Session 10 Mini Project 2 files
 │   │       └── profile_generator.py
 │   ├── L2/                  # Level 2 practice files
-│   │   ├── S1/ ... S9/
+│   │   ├── S1/ ... S9/      # Numbered session folders for regular sessions (mini projects are separate)
 │   │   ├── S5_MP1/
 │   │   └── S10_MP2/
 │   └── Working/             # Sandbox staging area for live-coding samples

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ python-fundamentals/
 │   ├── 01_Python-Fundamentals-MasterPlan.md   # 18-level course roadmap
 │   ├── RepositoryStructure.md                 # Authoritative structure doc
 │   └── sessions/
-│       ├── L1/   # Noob → Nerd (S1–S8, S5_MP1, S10_MP2, _Plan.md)
+│       ├── L1/   # Noob → Nerd (S1–S9, S5_MP1, S10_MP2, _Plan.md)
 │       └── L2/   # Nerd → Novice
 ├── src/
 │   ├── L1/       # Formal practice files: src/L1/S1/01_name.py

--- a/docs/RepositoryStructure.md
+++ b/docs/RepositoryStructure.md
@@ -198,7 +198,7 @@ Cursor AI configuration:
 
 - Format: `{number}_{descriptive_name}.py`
 - Examples: `01_hello.py`, `02_interactive_hello.py`, `03_type_conversion.py`
-- Location: `src/L{level}/S{session}/` or `src/L{level}/MP{number}/`
+- Location: `src/L{level}/S{session}/` (including session-aligned mini-project folders such as `S5_MP1/` and `S10_MP2/`)
 
 ### Session Documentation
 
@@ -206,6 +206,7 @@ Cursor AI configuration:
 - Plan: `_Plan.md` (underscore prefix sorts first)
 - Examples: `S1.md`, `S5_MP1.md`, `_Plan.md`
 - Location: `docs/sessions/L{level}/`
+- Note: pedagogical session numbers can differ from filename order because mini projects are stored as `S5_MP1.md` and `S10_MP2.md` in the same sequence.
 
 ### Images
 

--- a/docs/RepositoryStructure.md
+++ b/docs/RepositoryStructure.md
@@ -58,20 +58,20 @@ python-fundamentals/
 │       │   ├── 01_conditionals.py
 │       │   ├── 02_boolean_logic.py
 │       │   └── 03_number_guessing_game.py
-│       ├── S6/                 # Session 6 practice files
+│       ├── S6/                 # Session 5 practice files
 │       │   ├── 01_for_loops.py
 │       │   ├── 02_while_loops.py
 │       │   ├── 03_loop_controls_fizzbuzz.py
 │       │   └── 04_calculator_loop.py
-│       ├── S7/                 # Session 7 practice files
+│       ├── S7/                 # Session 6 practice files
 │       │   ├── 01_error_examples.py
 │       │   ├── 02_debug_practice.py
 │       │   └── 03_builtin_functions.py
-│       ├── S8/                 # Session 8 practice files
+│       ├── S8/                 # Session 7 practice files
 │       │   ├── 01_list_basics.py
 │       │   ├── 02_list_methods.py
 │       │   └── 03_task_manager.py
-│       ├── S9/                 # Session 9 practice files
+│       ├── S9/                 # Session 8 practice files
 │       │   ├── 01_dict_basics.py
 │       │   ├── 02_dict_iteration.py
 │       │   └── 03_gradebook.py
@@ -97,19 +97,19 @@ python-fundamentals/
 │       │   ├── 01_basic_error_handling.py
 │       │   ├── 02_multiple_exceptions.py
 │       │   └── 03_else_finally.py
-│       ├── S6/                 # Session 6 practice files
+│       ├── S6/                 # Session 5 practice files
 │       │   ├── 01_basic_parameters.py
 │       │   ├── 02_parameter_types.py
 │       │   └── 03_return_values.py
-│       ├── S7/                 # Session 7 practice files
+│       ├── S7/                 # Session 6 practice files
 │       │   ├── 01_local_scope.py
 │       │   ├── 02_global_scope.py
 │       │   └── 03_code_organization.py
-│       ├── S8/                 # Session 8 practice files
+│       ├── S8/                 # Session 7 practice files
 │       │   ├── 01_reading_files.py
 │       │   ├── 02_writing_files.py
 │       │   └── 03_file_operations.py
-│       ├── S9/                 # Session 9 practice files
+│       ├── S9/                 # Session 8 practice files
 │       │   ├── 01_creating_modules.py
 │       │   ├── 02_name_main.py
 │       │   └── 03_multi_file_project.py

--- a/src/L2/S10_MP2/contact_manager.py
+++ b/src/L2/S10_MP2/contact_manager.py
@@ -19,7 +19,7 @@ import os
 # ============================================================
 # CONSTANTS
 # ============================================================
-CONTACTS_FILE = "contacts.txt"
+CONTACTS_FILE = os.path.join(os.path.dirname(__file__), "contacts.txt")
 SEPARATOR = "|"
 
 


### PR DESCRIPTION
This pull request focuses on improving documentation clarity for the repository structure and fixing a file path bug in the `contact_manager.py` script. The main changes include correcting session folder descriptions and comments across several documentation files to better reflect the actual organization, and updating the contacts file path to be relative to the script location for improved portability.

Repository structure documentation updates:

* Updated session folder comments and descriptions in `.cursor/rules/02_repository-structure.mdc`, `docs/RepositoryStructure.md`, and `.github/copilot-instructions.md` to clarify which sessions each folder covers and to better distinguish between regular sessions and mini project folders. [[1]](diffhunk://#diff-41de857c4271360f8346eeeb989bba02a9a58cc98095ab4314a7b55f938d07aaL106-R119) [[2]](diffhunk://#diff-41de857c4271360f8346eeeb989bba02a9a58cc98095ab4314a7b55f938d07aaL145-R157) [[3]](diffhunk://#diff-7dad9d26906e2b28f1efa1a79219fc2d8c65faaed7cda69f25f226b3bf0cc0b7L61-R74) [[4]](diffhunk://#diff-7dad9d26906e2b28f1efa1a79219fc2d8c65faaed7cda69f25f226b3bf0cc0b7L100-R112) [[5]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L84-R91)
* Clarified the session numbering in `CLAUDE.md` to indicate that L1 covers S1–S9 instead of S1–S8.
* Improved documentation in `docs/RepositoryStructure.md` to explain the folder naming conventions for mini projects and session documentation, including notes about pedagogical session numbers and filename order.

Bug fix:

* Changed the `CONTACTS_FILE` path in `src/L2/S10_MP2/contact_manager.py` to use a path relative to the script location, ensuring the contacts file is always found regardless of the current working directory.