### PR TITLE
docs: fix level label and add L2 roadmap ASCII fallback (#36)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,4 @@ Repository agent guidance for automation and code assistants.
 ## Notes
 
 - This file is repository-local and complements `.github/copilot-instructions.md` and `CLAUDE.md`.
+- If guidance conflicts, follow this precedence: `docs/RepositoryStructure.md` (structure source of truth) → `.github/copilot-instructions.md` → `CLAUDE.md` → this file.

--- a/docs/sessions/L1/S10_MP2.md
+++ b/docs/sessions/L1/S10_MP2.md
@@ -515,7 +515,7 @@ You've completed **Level 1: Noob → Nerd**!
 
 ### **What's Next?**
 
-**Level 2: Nerd → Developer** will cover:
+**Level 2: Nerd → Novice** will cover:
 
 - Functions in depth
 - File handling

--- a/docs/sessions/L2/_Plan.md
+++ b/docs/sessions/L2/_Plan.md
@@ -155,6 +155,31 @@ flowchart TB
     class B5,C5 project
 ```
 
+ASCII fallback:
+
+```text
+[🎯 Nerd]
+    |
+    v
+[📘 Phase A: Advanced Foundations]
+    ├─ [📚 Session 1: Sets & Tuples]
+    ├─ [📚 Session 2: List Comprehensions]
+    ├─ [🔧 Session 3: Functions Basics]
+    ├─ [🛡️ Session 4: Error Handling]
+    └─ [🚀 MP1: Mini Project 1: Data Processor]
+    |
+    v
+[📘 Phase B: File Operations & Advanced Functions]
+    ├─ [🔧 Session 5: Functions: Parameters]
+    ├─ [🔧 Session 6: Functions: Scope]
+    ├─ [📁 Session 7: Text File I/O]
+    ├─ [📦 Session 8: Modules Deep Dive]
+    └─ [🚀 MP2: Mini Project 2: Contact Manager]
+    |
+    v
+[🎓 Novice]
+```
+
 ---
 
 ## 📅 **Session-by-Session Breakdown**


### PR DESCRIPTION
This pull request introduces clarifications and improvements to documentation files, focusing on agent guidance precedence, session naming consistency, and accessibility of planning diagrams.

Documentation clarifications and improvements:

* Added a clear precedence order for agent guidance files in `AGENTS.md`, specifying that `docs/RepositoryStructure.md` is the primary source of truth, followed by `.github/copilot-instructions.md`, `CLAUDE.md`, and then `AGENTS.md` itself.
* Updated the session progression in `docs/sessions/L1/S10_MP2.md` to rename "Level 2: Nerd → Developer" to "Level 2: Nerd → Novice" for consistency and clarity.

Accessibility and usability enhancements:

* Added an ASCII fallback version of the flowchart in `docs/sessions/L2/_Plan.md` to improve accessibility for users who cannot view the graphical diagram.Agent-Logs-Url: https://github.com/Swamy-s-Tech-Skills-Academy/python-fundamentals/sessions/621df7ec-a33a-4c11-a789-3233355ed933