### PR TITLE
Align L1 plan with actual Session 5 practice files (#38)

### DIFF
--- a/docs/RepositoryStructure.md
+++ b/docs/RepositoryStructure.md
@@ -66,7 +66,8 @@ python-fundamentals/
 │       ├── S7/                 # Session 6 practice files
 │       │   ├── 01_error_examples.py
 │       │   ├── 02_debug_practice.py
-│       │   └── 03_builtin_functions.py
+│       │   ├── 03_builtin_functions.py
+│       │   └── 04_pep8_style_refactor.py
 │       ├── S8/                 # Session 7 practice files
 │       │   ├── 01_list_basics.py
 │       │   ├── 02_list_methods.py
@@ -255,7 +256,7 @@ Cursor AI configuration:
 | 4 | `S4.md` | Conditionals & Modules | 3 files |
 | 5 | `S5_MP1.md` | Mini Project: Calculator | 2 files |
 | 6 | `S6.md` | Loops & Iteration | 4 files |
-| 7 | `S7.md` | Debugging & Built-ins | 3 files |
+| 7 | `S7.md` | Debugging & Built-ins | 4 files |
 | 8 | `S8.md` | Lists & Loops | 3 files |
 | 9 | `S9.md` | Dictionaries & Testing | 3 files |
 | 10 | `S10_MP2.md` | Mini Project: Profile Generator | 1 file |

--- a/docs/sessions/L1/_Plan.md
+++ b/docs/sessions/L1/_Plan.md
@@ -278,7 +278,7 @@ ASCII fallback:
 * Nested loops and performance considerations
 
 🧪 *Practice Files*:  
-`src/L1/S6/01_for_loops.py`, `src/L1/S6/02_while_loops.py`, `src/L1/S6/03_loop_controls_fizzbuzz.py`
+`src/L1/S6/01_for_loops.py`, `src/L1/S6/02_while_loops.py`, `src/L1/S6/03_loop_controls_fizzbuzz.py`, `src/L1/S6/04_calculator_loop.py`
 
 📖 *Documentation*: [S6.md](S6.md)
 


### PR DESCRIPTION
This pull request updates the documentation to reflect newly added and reorganized practice files for several sessions in the Python Fundamentals course. The changes ensure that the listed files and file counts accurately match the repository's structure and content.

Documentation updates for practice files:

* Added `04_pep8_style_refactor.py` to the list of Session 7 (`S7`) practice files in `docs/RepositoryStructure.md`, and updated the file count for `S7.md` from 3 to 4. [[1]](diffhunk://#diff-7dad9d26906e2b28f1efa1a79219fc2d8c65faaed7cda69f25f226b3bf0cc0b7L69-R70) [[2]](diffhunk://#diff-7dad9d26906e2b28f1efa1a79219fc2d8c65faaed7cda69f25f226b3bf0cc0b7L258-R259)
* Added `04_calculator_loop.py` to the list of Session 6 (`S6`) practice files in `docs/sessions/L1/_Plan.md`.* Fix L1 S7 file list in RepositoryStructure

Agent-Logs-Url: https://github.com/Swamy-s-Tech-Skills-Academy/python-fundamentals/sessions/1baab57c-fbab-4829-95c8-89c55ed24de0



* Fix L1 S7 practice-file count in RepositoryStructure status table

Agent-Logs-Url: https://github.com/Swamy-s-Tech-Skills-Academy/python-fundamentals/sessions/3c260552-4d4d-4ca8-a17c-c0f61536252c



* Fix L1 plan Session 5 practice file list

Agent-Logs-Url: https://github.com/Swamy-s-Tech-Skills-Academy/python-fundamentals/sessions/9b52b652-cf62-4d91-b684-995fcf857af4



---------